### PR TITLE
Update peerDependency RX version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node-uuid": "^1.4.1"
   },
   "peerDependencies": {
-    "rx": "^2.3.14"
+    "rx": "^3.0.0"
   },
   "devDependencies": {
     "bluebird": "^2.5.3",


### PR DESCRIPTION
NPM is failing to install due to the way peerDependencies are handled now.  

```
npm install git+ssh://git@github.com/fdecampredon/rx-flux.git
npm WARN peerDependencies The peer dependency rx@^2.3.14 included from rx-flux will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Darwin 14.4.0
npm ERR! argv "/Users/rl/.nvm/versions/io.js/v2.3.1/bin/iojs" "/Users/rl/.nvm/versions/io.js/v2.3.1/bin/npm" "install" "git+ssh://git@github.com/fdecampredon/rx-flux.git"
npm ERR! node v2.3.1
npm ERR! npm  v2.11.3
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package rx does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer rx-react@0.2.1 wants rx@^3.0.0
npm ERR! peerinvalid Peer rx-flux@0.2.0 wants rx@^2.3.14

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/rl/Sites/LumeFX/LumeFX-UI/npm-debug.log
```

Updating the Rx dependency to 3.0.0 should fix this